### PR TITLE
Add a target for "npm test" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
             "url": "http://github.com/andris9/pass/blob/master/LICENSE"
         }
     ],
-    "keywords": ["apache", "password", "passwd", "htpasswd"]
+    "keywords": ["apache", "password", "passwd", "htpasswd"],
+    "scripts" : {
+        "test" : "node test.js"
+    }
 }


### PR DESCRIPTION
Hiya,

Just thought I'd add the test target for npm, which can be invoked with:

```
$ npm test
```

Many thanks,
Andy
